### PR TITLE
[Refactor] 디자인 시스템 토큰 체계 구축 및 typography 스프레드 적용

### DIFF
--- a/src/pages/home/Home.css.ts
+++ b/src/pages/home/Home.css.ts
@@ -11,5 +11,5 @@ export const bar = style({
   height: "5px",
   marginLeft: "-16px",
   marginRight: "-16px",
-  backgroundColor: vars.color.grey[300],
+  backgroundColor: vars.color.role.line,
 });

--- a/src/pages/home/components/HomeGreetingSection/HomeBanner/HomeBanner.css.ts
+++ b/src/pages/home/components/HomeGreetingSection/HomeBanner/HomeBanner.css.ts
@@ -37,7 +37,7 @@ export const title = style({
   margin: 0,
   ...vars.typography.body1,
   textAlign: "center",
-  color: "#303030",
+  color: vars.color.role.text,
 });
 
 export const circleTopRight = style({

--- a/src/pages/home/components/HomeGreetingSection/HomeBanner/HomeBanner.css.ts
+++ b/src/pages/home/components/HomeGreetingSection/HomeBanner/HomeBanner.css.ts
@@ -30,7 +30,7 @@ export const label = style({
   fontSize: 11,
   fontWeight: "500",
   lineHeight: "150%",
-  color: vars.color.blueGreen.dark,
+  color: vars.color.role.secondary,
 });
 
 export const title = style({

--- a/src/pages/home/components/HomeGreetingSection/HomeBanner/HomeBanner.css.ts
+++ b/src/pages/home/components/HomeGreetingSection/HomeBanner/HomeBanner.css.ts
@@ -10,7 +10,7 @@ export const container = style({
   flexDirection: "column",
   alignItems: "center",
   overflow: "hidden",
-  background: "linear-gradient(181deg, #F7FAFF 0%, #FFFFFF 15%, #C6EDFF 100%)",
+  background: `linear-gradient(181deg, #F7FAFF 0%, ${vars.color.role.background} 15%, #C6EDFF 100%)`,
   minHeight: 120,
 });
 
@@ -35,9 +35,7 @@ export const label = style({
 
 export const title = style({
   margin: 0,
-  fontSize: 16,
-  fontWeight: 700,
-  lineHeight: "150%",
+  ...vars.typography.body1,
   textAlign: "center",
   color: "#303030",
 });

--- a/src/pages/home/components/HomeGreetingSection/HomeGreetingSection.css.ts
+++ b/src/pages/home/components/HomeGreetingSection/HomeGreetingSection.css.ts
@@ -8,7 +8,7 @@ export const container = style({
   display: "flex",
   flexDirection: "column",
   alignItems: "center",
-  background: "#ffffff",
+  background: vars.color.role.background,
   paddingTop: 24,
   paddingBottom: 24,
   paddingLeft: 16,
@@ -22,7 +22,7 @@ export const textArea = style({
   flexDirection: "column",
   alignItems: "left",
   gap: 4,
-  background: "#ffffff",
+  background: vars.color.role.background,
 });
 
 export const title = style({
@@ -30,7 +30,7 @@ export const title = style({
   fontSize: 18,
   fontWeight: 600,
   lineHeight: "150%",
-  color: vars.color.grey[900],
+  color: vars.color.role.text,
   display: "flex",
   flexDirection: "column",
   alignItems: "left",
@@ -41,8 +41,7 @@ export const subTitle = style({
   display: "flex",
   flexDirection: "column",
   alignItems: "left",
-  background: "#ffffff",
-  fontSize: 12,
-  fontWeight: 400,
-  color: vars.color.grey[400],
+  background: vars.color.role.background,
+  ...vars.typography.caption1,
+  color: vars.color.role.grey,
 });

--- a/src/pages/home/components/HomeGreetingSection/HomeWallet/HomeWallet.css.ts
+++ b/src/pages/home/components/HomeGreetingSection/HomeWallet/HomeWallet.css.ts
@@ -39,7 +39,7 @@ export const ctaMyWalletVector = style({
 export const currentTime = style({
   width: "fit-content",
   ...vars.typography.caption1,
-  color: vars.color.grey[600],
+  color: vars.color.role.grey,
 });
 
 export const buttonWrapper = style({
@@ -60,13 +60,13 @@ export const button = style({
   display: "flex",
   justifyContent: "space-between",
   alignItems: "center",
-  backgroundColor: vars.color.grey[50],
+  backgroundColor: vars.color.role.background2,
   borderRadius: 16,
 });
 
 export const currency = style({
   ...vars.typography.body5,
-  color: vars.color.grey[600],
+  color: vars.color.role.grey,
 });
 
 export const balance = style({

--- a/src/pages/home/components/HomeGreetingSection/HomeWallet/HomeWallet.css.ts
+++ b/src/pages/home/components/HomeGreetingSection/HomeWallet/HomeWallet.css.ts
@@ -29,7 +29,7 @@ globalStyle(`${ctaMyWallet} > span`, {
   width: "fit-content",
   fontSize: 12,
   fontWeight: 600,
-  color: vars.color.grey[800],
+  color: vars.color.role.subtext,
 });
 
 export const ctaMyWalletVector = style({
@@ -38,8 +38,7 @@ export const ctaMyWalletVector = style({
 
 export const currentTime = style({
   width: "fit-content",
-  fontSize: 12,
-  fontWeight: 400,
+  ...vars.typography.caption1,
   color: vars.color.grey[600],
 });
 
@@ -66,13 +65,11 @@ export const button = style({
 });
 
 export const currency = style({
-  fontSize: 14,
-  fontWeight: 400,
+  ...vars.typography.body5,
   color: vars.color.grey[600],
 });
 
 export const balance = style({
-  fontSize: 14,
-  fontWeight: 700,
-  color: vars.color.grey[900],
+  ...vars.typography.body3,
+  color: vars.color.role.text,
 });

--- a/src/pages/home/components/HomeGreetingSection/HomeWallet/HomeWallet.css.ts
+++ b/src/pages/home/components/HomeGreetingSection/HomeWallet/HomeWallet.css.ts
@@ -27,8 +27,7 @@ export const ctaMyWallet = style({
 
 globalStyle(`${ctaMyWallet} > span`, {
   width: "fit-content",
-  fontSize: 12,
-  fontWeight: 600,
+  ...vars.typography.caption2,
   color: vars.color.role.subtext,
 });
 

--- a/src/pages/home/components/HomeMarketSection/HomeMarketSection.css.ts
+++ b/src/pages/home/components/HomeMarketSection/HomeMarketSection.css.ts
@@ -12,14 +12,13 @@ export const container = style({
   display: "flex",
   flexDirection: "column",
   gap: 12,
-  background: "#ffffff",
+  background: vars.color.role.background,
 });
 
 export const sectionTitle = style({
   width: "100%",
-  fontSize: 14,
-  fontWeight: 700,
-  color: vars.color.grey[800],
+  ...vars.typography.body3,
+  color: vars.color.role.subtext,
 });
 
 export const verticalList = style({});

--- a/src/pages/home/components/HomeMarketSection/MarketCard/MarketCard.css.ts
+++ b/src/pages/home/components/HomeMarketSection/MarketCard/MarketCard.css.ts
@@ -5,7 +5,7 @@ const base = style({
   flexShrink: 0,
   borderRadius: 16,
   overflow: "hidden",
-  backgroundColor: vars.color.grey[50],
+  backgroundColor: vars.color.role.background2,
 });
 
 export const layout = styleVariants({
@@ -39,7 +39,7 @@ export const logo = style({
   width: 40,
   height: 40,
   borderRadius: "50%",
-  backgroundColor: vars.color.grey[100],
+  backgroundColor: vars.color.role.line,
   flexShrink: 0,
   objectFit: "cover",
 });
@@ -89,8 +89,8 @@ export const badge = style({
   fontWeight: 500,
   // lineHeight: 1.5,
   whiteSpace: "nowrap",
-  backgroundColor: vars.color.blueGreen.light,
-  color: vars.color.blueGreen.dark,
+  backgroundColor: vars.color.role.background2,
+  color: vars.color.role.secondary,
 });
 
 export const priceRow = style({

--- a/src/pages/home/components/HomeMarketSection/MarketCard/MarketCard.css.ts
+++ b/src/pages/home/components/HomeMarketSection/MarketCard/MarketCard.css.ts
@@ -85,9 +85,7 @@ export const badge = style({
   alignItems: "center",
   padding: "3px 8px 2px",
   borderRadius: 40,
-  fontSize: 12,
-  fontWeight: 500,
-  // lineHeight: 1.5,
+  ...vars.typography.label2,
   whiteSpace: "nowrap",
   backgroundColor: vars.color.role.background2,
   color: vars.color.role.secondary,
@@ -101,14 +99,10 @@ export const priceRow = style({
 });
 
 export const changeRate = style({
-  fontSize: 14,
-  fontWeight: 700,
-  lineHeight: 1.5,
+  ...vars.typography.body3,
 });
 
 export const price = style({
-  fontSize: 12,
-  fontWeight: 700,
+  ...vars.typography.label1,
   color: vars.color.role.subtext,
-  lineHeight: 1.5,
 });

--- a/src/pages/home/components/HomeMarketSection/MarketCard/MarketCard.css.ts
+++ b/src/pages/home/components/HomeMarketSection/MarketCard/MarketCard.css.ts
@@ -70,10 +70,8 @@ export const nameRow = styleVariants({
 });
 
 export const name = style({
-  fontSize: 14,
-  fontWeight: 700,
-  color: vars.color.grey[900],
-  lineHeight: "150%",
+  ...vars.typography.body3,
+  color: vars.color.role.text,
   whiteSpace: "nowrap",
   overflow: "hidden",
   textOverflow: "ellipsis",
@@ -111,6 +109,6 @@ export const changeRate = style({
 export const price = style({
   fontSize: 12,
   fontWeight: 700,
-  color: vars.color.grey[800],
+  color: vars.color.role.subtext,
   lineHeight: 1.5,
 });

--- a/src/pages/home/components/HomeStockSection/HomeStockSection.css.ts
+++ b/src/pages/home/components/HomeStockSection/HomeStockSection.css.ts
@@ -24,10 +24,8 @@ export const ctaMyStocks = style({
 });
 
 export const ctaMyStockTitle = style({
-  fontSize: 12,
-  fontWeight: 600,
+  ...vars.typography.caption2,
   color: vars.color.role.subtext,
-  lineHeight: "150%",
 });
 
 export const ctaMyStockVector = style({

--- a/src/pages/home/components/HomeStockSection/HomeStockSection.css.ts
+++ b/src/pages/home/components/HomeStockSection/HomeStockSection.css.ts
@@ -9,7 +9,7 @@ export const container = style({
   flexDirection: "column",
   alignItems: "center",
   gap: 12,
-  background: "#ffffff",
+  background: vars.color.role.background,
   paddingTop: 24,
   paddingBottom: 24,
   paddingLeft: 16,
@@ -26,7 +26,7 @@ export const ctaMyStocks = style({
 export const ctaMyStockTitle = style({
   fontSize: 12,
   fontWeight: 600,
-  color: vars.color.grey[800],
+  color: vars.color.role.subtext,
   lineHeight: "150%",
 });
 
@@ -43,16 +43,12 @@ export const balanceContainer = style({
 });
 
 export const currentBalance = style({
-  fontSize: 24,
-  fontWeight: 700,
-  color: "#1a1a1a",
-  lineHeight: "150%",
+  ...vars.typography.h1,
+  color: vars.color.role.text,
 });
 
 export const currentVariation = style({
   paddingBottom: 4,
-  fontSize: 16,
-  fontWeight: 500,
+  ...vars.typography.body2,
   color: "#FF383C",
-  lineHeight: "150%",
 });

--- a/src/pages/home/components/HomeStockSection/StockAnalysis/StockAnalysis.css.ts
+++ b/src/pages/home/components/HomeStockSection/StockAnalysis/StockAnalysis.css.ts
@@ -34,16 +34,14 @@ export const titleWrapper = style({
 });
 
 export const title = style({
-  fontSize: 12,
-  fontWeight: 500,
+  ...vars.typography.label2,
   color: vars.color.role.primary,
 });
 
 export const sparkleIcon = style({ flexShrink: 0 });
 
 export const analysisContent = style({
-  fontSize: 12,
-  fontWeight: 700,
+  ...vars.typography.label1,
   color: vars.color.role.subcolor,
   whiteSpace: "pre-line",
 });

--- a/src/pages/home/components/HomeStockSection/StockAnalysis/StockAnalysis.css.ts
+++ b/src/pages/home/components/HomeStockSection/StockAnalysis/StockAnalysis.css.ts
@@ -9,7 +9,7 @@ export const container = style({
 
   display: "flex",
   gap: 20,
-  backgroundColor: "#fffff",
+  backgroundColor: vars.color.role.background,
   borderRadius: 16,
   boxShadow: "0px 1px 6px rgba(0, 0, 0, 0.08)",
 });
@@ -36,7 +36,7 @@ export const titleWrapper = style({
 export const title = style({
   fontSize: 12,
   fontWeight: 500,
-  color: vars.color.blue.normal,
+  color: vars.color.role.primary,
 });
 
 export const sparkleIcon = style({ flexShrink: 0 });
@@ -44,6 +44,6 @@ export const sparkleIcon = style({ flexShrink: 0 });
 export const analysisContent = style({
   fontSize: 12,
   fontWeight: 700,
-  color: vars.color.blue.darkActive,
+  color: vars.color.role.subcolor,
   whiteSpace: "pre-line",
 });

--- a/src/pages/home/components/HomeStockSection/StockList/MyStockContent.css.ts
+++ b/src/pages/home/components/HomeStockSection/StockList/MyStockContent.css.ts
@@ -13,7 +13,7 @@ export const container = style({
 
   borderTopWidth: 1,
   borderTopStyle: "solid",
-  borderTopColor: "#F6F6F6",
+  borderTopColor: vars.color.role.background2,
 });
 
 export const corpInfoWrapper = style({
@@ -39,15 +39,13 @@ export const corpInfoTitleWrapper = style({
 });
 
 export const corpInfoTitle = style({
-  fontSize: 14,
-  fontWeight: 700,
-  color: vars.color.grey[900],
+  ...vars.typography.body3,
+  color: vars.color.role.text,
 });
 
 export const averagePrice = style({
-  fontSize: 14,
-  fontWeight: 500,
-  color: vars.color.grey[800],
+  ...vars.typography.body4,
+  color: vars.color.role.subtext,
 });
 
 export const priceWrapper = style({
@@ -60,19 +58,16 @@ export const priceWrapper = style({
 });
 
 export const currentPrice = style({
-  fontSize: 14,
-  fontWeight: 700,
-  color: vars.color.grey[900],
+  ...vars.typography.body3,
+  color: vars.color.role.text,
 });
 
 export const increase = style({
-  fontSize: 14,
-  fontWeight: 500,
-  color: "#FB2C36",
+  ...vars.typography.body4,
+  color: "#FF383C",
 });
 
 export const decrease = style({
-  fontSize: 14,
-  fontWeight: 500,
-  color: "#0088FF",
+  ...vars.typography.body4,
+  color: "#2E7BF6",
 });

--- a/src/pages/home/components/HomeStockSection/StockList/StockList.css.ts
+++ b/src/pages/home/components/HomeStockSection/StockList/StockList.css.ts
@@ -26,16 +26,16 @@ globalStyle(`${badgeList} > button`, {
   height: 30,
   fontSize: 12,
   fontWeight: 700,
-  color: vars.color.grey[800],
+  color: vars.color.role.subtext,
 
   borderRadius: 100,
   borderWidth: 1,
   borderStyle: "solid",
-  borderColor: vars.color.grey[100],
+  borderColor: vars.color.role.line,
 });
 
 globalStyle(`${badgeList} > button[aria-selected="true"]`, {
-  backgroundColor: "#F6F6F6",
+  backgroundColor: vars.color.role.background2,
   border: "none",
 });
 

--- a/src/pages/home/components/HomeStockSection/StockList/StockList.css.ts
+++ b/src/pages/home/components/HomeStockSection/StockList/StockList.css.ts
@@ -24,8 +24,7 @@ globalStyle(`${badgeList} > button`, {
 
   width: "fit-content",
   height: 30,
-  fontSize: 12,
-  fontWeight: 700,
+  ...vars.typography.label1,
   color: vars.color.role.subtext,
 
   borderRadius: 100,

--- a/src/shared/styles/color.role.css.ts
+++ b/src/shared/styles/color.role.css.ts
@@ -1,0 +1,11 @@
+export const roleColor = {
+  primary: "#00BECC",
+  secondary: "#008F99",
+  subcolor: "#00555C",
+  background: "#FFFFFF",
+  background2: "#F6F6F6",
+  line: "#E8E8E8",
+  grey: "#C5C5C5",
+  subtext: "#646464",
+  text: "#1A1A1A",
+} as const;

--- a/src/shared/styles/color.semantic.css.ts
+++ b/src/shared/styles/color.semantic.css.ts
@@ -1,6 +1,8 @@
 import { green, blue, grey, blueGreen } from "./color.scale.css";
+import { roleColor } from "./color.role.css";
 
 export const color = {
+  role: roleColor,
   green: {
     light: green[50],
     lightHover: green[100],

--- a/src/shared/styles/typography.css.ts
+++ b/src/shared/styles/typography.css.ts
@@ -13,6 +13,9 @@ export const typography = {
   body5: { fontSize: "14px", fontWeight: "400", lineHeight: "150%" },
 
   caption1: { fontSize: "12px", fontWeight: "400", lineHeight: "150%" },
-  caption2: { fontSize: "12px", fontWeight: "400", lineHeight: "150%" },
+  caption2: { fontSize: "12px", fontWeight: "600", lineHeight: "150%" },
   caption3: { fontSize: "11px", fontWeight: "400", lineHeight: "150%" },
+
+  label1: { fontSize: "12px", fontWeight: "700", lineHeight: "150%" },
+  label2: { fontSize: "12px", fontWeight: "500", lineHeight: "150%" },
 } as const;

--- a/src/shared/styles/typography.css.ts
+++ b/src/shared/styles/typography.css.ts
@@ -1,0 +1,18 @@
+export const typography = {
+  h1: { fontSize: "24px", fontWeight: "700", lineHeight: "150%" },
+  h2: { fontSize: "24px", fontWeight: "500", lineHeight: "150%" },
+
+  subtitle1: { fontSize: "20px", fontWeight: "700", lineHeight: "150%" },
+  subtitle2: { fontSize: "20px", fontWeight: "500", lineHeight: "150%" },
+  subtitle3: { fontSize: "18px", fontWeight: "500", lineHeight: "150%" },
+
+  body1: { fontSize: "16px", fontWeight: "700", lineHeight: "150%" },
+  body2: { fontSize: "16px", fontWeight: "500", lineHeight: "150%" },
+  body3: { fontSize: "14px", fontWeight: "700", lineHeight: "150%" },
+  body4: { fontSize: "14px", fontWeight: "500", lineHeight: "150%" },
+  body5: { fontSize: "14px", fontWeight: "400", lineHeight: "150%" },
+
+  caption1: { fontSize: "12px", fontWeight: "400", lineHeight: "150%" },
+  caption2: { fontSize: "12px", fontWeight: "400", lineHeight: "150%" },
+  caption3: { fontSize: "11px", fontWeight: "400", lineHeight: "150%" },
+} as const;

--- a/src/shared/styles/vars.css.ts
+++ b/src/shared/styles/vars.css.ts
@@ -1,5 +1,6 @@
 import { createTheme } from "@vanilla-extract/css";
 import { color } from "./color.semantic.css";
+import { typography } from "./typography.css";
 
 export const [themeClass, vars] = createTheme({
   color: {
@@ -7,5 +8,7 @@ export const [themeClass, vars] = createTheme({
     blue: color.blue,
     blueGreen: color.blueGreen,
     grey: color.grey,
+    role: color.role,
   },
+  typography,
 });


### PR DESCRIPTION
## Pull Request Title

refactor: 디자인 시스템 토큰 체계 구축 및 typography 스프레드 적용

<br>

## PR 설명

- [x] `color.role.css.ts` 신규 추가 — 시맨틱 role 색상 토큰 정의 (background, text, primary 등)
- [x] `typography.css.ts` 신규 추가 — h1~h2, subtitle1~3, body1~5, caption1~3, label1~2 타이포그래피 토큰 정의
- [x] `vars.css.ts`, `color.semantic.css.ts`에 role 색상 및 typography 토큰 통합
- [x] Home 페이지 전체 css.ts 파일의 하드코딩된 color 값을 role 토큰으로 교체
- [x] Home 페이지 전체 css.ts 파일의 개별 fontSize/fontWeight/lineHeight → `...vars.typography.*` 스프레드로 통일

<br>

## 리뷰 반영 내용

- `HomeBanner` title의 하드코딩 color `"#303030"` → `vars.color.role.text`
- `HomeWallet` ctaMyWallet>span의 fontSize/fontWeight → `vars.typography.caption2`
- `HomeStockSection` ctaMyStockTitle의 fontSize/fontWeight/lineHeight → `vars.typography.caption2`
- `MarketCard` badge/changeRate/price의 개별 fontSize/fontWeight → `label2` / `body3` / `label1` 토큰
- `StockList` badgeList>button의 fontSize/fontWeight → `vars.typography.label1`
- `StockAnalysis` title/analysisContent의 fontSize/fontWeight → `label2` / `label1` 토큰
- typography에 `caption2`(600), `label1`(700), `label2`(500) 토큰 신규 추가

<br>

## 스크린샷

<img width="320" height="93" alt="image" src="https://github.com/user-attachments/assets/ba3eab05-5b61-45aa-8b72-55e282ee0ef4" />

이런 식으로 사용하시면 됩니다!

<br>

## 추가 설명

- 빌드 검증 완료 (`pnpm build`)
- 토큰 정의 커밋과 스프레드 리팩터링 커밋을 분리하여 히스토리 관리