### PR TITLE
[FEAT] 공용 컴포넌트 추출 (ChangeRate, Badge, Logo)

### DIFF
--- a/src/pages/home/components/HomeMarketSection/MarketCard/MarketCard.css.ts
+++ b/src/pages/home/components/HomeMarketSection/MarketCard/MarketCard.css.ts
@@ -98,10 +98,6 @@ export const priceRow = style({
   gap: 6,
 });
 
-export const changeRate = style({
-  ...vars.typography.body3,
-});
-
 export const price = style({
   ...vars.typography.label1,
   color: vars.color.role.subtext,

--- a/src/pages/home/components/HomeMarketSection/MarketCard/MarketCard.css.ts
+++ b/src/pages/home/components/HomeMarketSection/MarketCard/MarketCard.css.ts
@@ -35,15 +35,6 @@ export const layout = styleVariants({
   ],
 });
 
-export const logo = style({
-  width: 40,
-  height: 40,
-  borderRadius: "50%",
-  backgroundColor: vars.color.role.line,
-  flexShrink: 0,
-  objectFit: "cover",
-});
-
 export const info = styleVariants({
   horizontal: {
     display: "flex",

--- a/src/pages/home/components/HomeMarketSection/MarketCard/MarketCard.css.ts
+++ b/src/pages/home/components/HomeMarketSection/MarketCard/MarketCard.css.ts
@@ -77,20 +77,6 @@ export const name = style({
   textOverflow: "ellipsis",
 });
 
-export const badge = style({
-  minWidth: 32,
-  height: 22,
-  display: "inline-flex",
-  justifyContent: "center",
-  alignItems: "center",
-  padding: "3px 8px 2px",
-  borderRadius: 40,
-  ...vars.typography.label2,
-  whiteSpace: "nowrap",
-  backgroundColor: vars.color.role.background2,
-  color: vars.color.role.secondary,
-});
-
 export const priceRow = style({
   marginTop: 2,
   display: "flex",

--- a/src/pages/home/components/HomeMarketSection/MarketCard/MarketCard.tsx
+++ b/src/pages/home/components/HomeMarketSection/MarketCard/MarketCard.tsx
@@ -1,4 +1,5 @@
 import * as styles from "./MarketCard.css";
+import ChangeRate from "@/shared/components/ChangeRate";
 
 interface MarketCardProps {
   variant: "horizontal" | "vertical";
@@ -17,10 +18,6 @@ export default function MarketCard({
   price,
   logoUrl,
 }: MarketCardProps) {
-  const isPositive = changeRate >= 0;
-  const changeColor = isPositive ? "#FF383C" : "#2E7BF6";
-  const changeText = `${isPositive ? "+" : ""}${changeRate}%`;
-
   return (
     <div className={styles.layout[variant]}>
       <img className={styles.logo} src={logoUrl} alt={name} />
@@ -30,9 +27,7 @@ export default function MarketCard({
           <span className={styles.badge}>{sector}</span>
         </div>
         <div className={styles.priceRow}>
-          <span className={styles.changeRate} style={{ color: changeColor }}>
-            {changeText}
-          </span>
+          <ChangeRate value={changeRate} typography="body3" />
           <span className={styles.price}>{price}</span>
         </div>
       </div>

--- a/src/pages/home/components/HomeMarketSection/MarketCard/MarketCard.tsx
+++ b/src/pages/home/components/HomeMarketSection/MarketCard/MarketCard.tsx
@@ -1,5 +1,5 @@
 import * as styles from "./MarketCard.css";
-import { Badge, ChangeRate } from "@/shared/components";
+import { Badge, ChangeRate, Logo } from "@/shared/components";
 
 interface MarketCardProps {
   variant: "horizontal" | "vertical";
@@ -20,7 +20,7 @@ export default function MarketCard({
 }: MarketCardProps) {
   return (
     <div className={styles.layout[variant]}>
-      <img className={styles.logo} src={logoUrl} alt={name} />
+      <Logo src={logoUrl} alt={name} size={40} />
       <div className={styles.info[variant]}>
         <div className={styles.nameRow[variant]}>
           <span className={styles.name}>{name}</span>

--- a/src/pages/home/components/HomeMarketSection/MarketCard/MarketCard.tsx
+++ b/src/pages/home/components/HomeMarketSection/MarketCard/MarketCard.tsx
@@ -1,5 +1,5 @@
 import * as styles from "./MarketCard.css";
-import ChangeRate from "@/shared/components/ChangeRate";
+import { Badge, ChangeRate } from "@/shared/components";
 
 interface MarketCardProps {
   variant: "horizontal" | "vertical";
@@ -24,7 +24,7 @@ export default function MarketCard({
       <div className={styles.info[variant]}>
         <div className={styles.nameRow[variant]}>
           <span className={styles.name}>{name}</span>
-          <span className={styles.badge}>{sector}</span>
+          <Badge>{sector}</Badge>
         </div>
         <div className={styles.priceRow}>
           <ChangeRate value={changeRate} typography="body3" />

--- a/src/pages/home/components/HomeStockSection/HomeStockSection.css.ts
+++ b/src/pages/home/components/HomeStockSection/HomeStockSection.css.ts
@@ -47,6 +47,4 @@ export const currentBalance = style({
 
 export const currentVariation = style({
   paddingBottom: 4,
-  ...vars.typography.body2,
-  color: "#FF383C",
 });

--- a/src/pages/home/components/HomeStockSection/HomeStockSection.mock.ts
+++ b/src/pages/home/components/HomeStockSection/HomeStockSection.mock.ts
@@ -1,6 +1,7 @@
 export const MOCK_BALANCE = {
   total: "49,350 원",
-  variation: "+1,800원 (3.7%)",
+  variationAmount: 1800,
+  variationRate: 3.7,
 };
 
 export const MOCK_STOCKS = [

--- a/src/pages/home/components/HomeStockSection/HomeStockSection.tsx
+++ b/src/pages/home/components/HomeStockSection/HomeStockSection.tsx
@@ -6,6 +6,7 @@ import { VectorRight } from "@/assets/icons/components";
 
 import StockAnalysis from "./StockAnalysis/StockAnalysis";
 import StockList from "./StockList/StockList";
+import ChangeRate from "@/shared/components/ChangeRate";
 
 const FILTERS = ["직접 설정한 순", "현재가", "평가금액"] as const;
 type Filter = (typeof FILTERS)[number];
@@ -25,9 +26,13 @@ export default function HomeStockSection() {
       </button>
       <div className={styles.balanceContainer}>
         <span className={styles.currentBalance}>{MOCK_BALANCE.total}</span>
-        <span className={styles.currentVariation}>
-          {MOCK_BALANCE.variation}
-        </span>
+        <ChangeRate
+          value={MOCK_BALANCE.variationRate}
+          typography="body2"
+          className={styles.currentVariation}
+        >
+          {`+${MOCK_BALANCE.variationAmount.toLocaleString()}원 (${MOCK_BALANCE.variationRate}%)`}
+        </ChangeRate>
       </div>
       <StockList
         filters={FILTERS}

--- a/src/pages/home/components/HomeStockSection/HomeStockSection.tsx
+++ b/src/pages/home/components/HomeStockSection/HomeStockSection.tsx
@@ -6,7 +6,7 @@ import { VectorRight } from "@/assets/icons/components";
 
 import StockAnalysis from "./StockAnalysis/StockAnalysis";
 import StockList from "./StockList/StockList";
-import ChangeRate from "@/shared/components/ChangeRate";
+import { ChangeRate } from "@/shared/components";
 
 const FILTERS = ["직접 설정한 순", "현재가", "평가금액"] as const;
 type Filter = (typeof FILTERS)[number];

--- a/src/pages/home/components/HomeStockSection/StockList/MyStockContent.css.ts
+++ b/src/pages/home/components/HomeStockSection/StockList/MyStockContent.css.ts
@@ -23,13 +23,6 @@ export const corpInfoWrapper = style({
   gap: 16,
 });
 
-export const corpInfoLogo = style({
-  width: 46,
-  height: 46,
-  borderRadius: 1000,
-  backgroundColor: "#FEF2F2",
-});
-
 export const corpInfoTitleWrapper = style({
   width: "fit-content",
   display: "flex",

--- a/src/pages/home/components/HomeStockSection/StockList/MyStockContent.css.ts
+++ b/src/pages/home/components/HomeStockSection/StockList/MyStockContent.css.ts
@@ -61,13 +61,3 @@ export const currentPrice = style({
   ...vars.typography.body3,
   color: vars.color.role.text,
 });
-
-export const increase = style({
-  ...vars.typography.body4,
-  color: "#FF383C",
-});
-
-export const decrease = style({
-  ...vars.typography.body4,
-  color: "#2E7BF6",
-});

--- a/src/pages/home/components/HomeStockSection/StockList/MyStockContent.tsx
+++ b/src/pages/home/components/HomeStockSection/StockList/MyStockContent.tsx
@@ -1,4 +1,5 @@
 import * as styles from "./MyStockContent.css";
+import ChangeRate from "@/shared/components/ChangeRate";
 
 interface MyStockContentProps {
   name: string;
@@ -13,8 +14,6 @@ export default function MyStockContent({
   currentPrice,
   changeRate,
 }: MyStockContentProps) {
-  const isPositive = changeRate >= 0;
-
   return (
     <div className={styles.container}>
       <div className={styles.corpInfoWrapper}>
@@ -26,10 +25,7 @@ export default function MyStockContent({
       </div>
       <div className={styles.priceWrapper}>
         <span className={styles.currentPrice}>{currentPrice}</span>
-        <span className={isPositive ? styles.increase : styles.decrease}>
-          {isPositive ? "+" : ""}
-          {changeRate}%
-        </span>
+        <ChangeRate value={changeRate} />
       </div>
     </div>
   );

--- a/src/pages/home/components/HomeStockSection/StockList/MyStockContent.tsx
+++ b/src/pages/home/components/HomeStockSection/StockList/MyStockContent.tsx
@@ -1,5 +1,5 @@
 import * as styles from "./MyStockContent.css";
-import { ChangeRate } from "@/shared/components";
+import { ChangeRate, Logo } from "@/shared/components";
 
 interface MyStockContentProps {
   name: string;
@@ -17,7 +17,7 @@ export default function MyStockContent({
   return (
     <div className={styles.container}>
       <div className={styles.corpInfoWrapper}>
-        <div className={styles.corpInfoLogo}></div>
+        <Logo src={undefined} alt={name} size={46} />
         <div className={styles.corpInfoTitleWrapper}>
           <span className={styles.corpInfoTitle}>{name}</span>
           <span className={styles.averagePrice}>{averagePrice}</span>

--- a/src/pages/home/components/HomeStockSection/StockList/MyStockContent.tsx
+++ b/src/pages/home/components/HomeStockSection/StockList/MyStockContent.tsx
@@ -1,5 +1,5 @@
 import * as styles from "./MyStockContent.css";
-import ChangeRate from "@/shared/components/ChangeRate";
+import { ChangeRate } from "@/shared/components";
 
 interface MyStockContentProps {
   name: string;

--- a/src/shared/components/Badge/Badge.css.ts
+++ b/src/shared/components/Badge/Badge.css.ts
@@ -1,0 +1,14 @@
+import { style } from "@vanilla-extract/css";
+import { vars } from "@/shared/styles/vars.css";
+
+export const badge = style({
+  display: "inline-flex",
+  justifyContent: "center",
+  alignItems: "center",
+  whiteSpace: "nowrap",
+  padding: "3px 8px 2px",
+  borderRadius: 40,
+  ...vars.typography.caption2,
+  backgroundColor: `color-mix(in srgb, ${vars.color.role.secondary} 5%, transparent)`,
+  color: vars.color.role.secondary,
+});

--- a/src/shared/components/Badge/Badge.tsx
+++ b/src/shared/components/Badge/Badge.tsx
@@ -1,0 +1,14 @@
+import * as styles from "./Badge.css";
+
+interface BadgeProps {
+  className?: string;
+  children: React.ReactNode;
+}
+
+export function Badge({ className, children }: BadgeProps) {
+  return (
+    <span className={[styles.badge, className].filter(Boolean).join(" ")}>
+      {children}
+    </span>
+  );
+}

--- a/src/shared/components/ChangeRate/ChangeRate.css.ts
+++ b/src/shared/components/ChangeRate/ChangeRate.css.ts
@@ -1,0 +1,14 @@
+import { styleVariants } from "@vanilla-extract/css";
+import { vars } from "@/shared/styles/vars.css";
+
+export const directionStyle = styleVariants({
+  positive: { color: vars.color.accent.red },
+  negative: { color: vars.color.accent.blue },
+  neutral: { color: vars.color.role.subtext },
+});
+
+export const typographyStyle = styleVariants({
+  body2: { ...vars.typography.body2 },
+  body3: { ...vars.typography.body3 },
+  body4: { ...vars.typography.body4 },
+});

--- a/src/shared/components/ChangeRate/ChangeRate.tsx
+++ b/src/shared/components/ChangeRate/ChangeRate.tsx
@@ -1,0 +1,31 @@
+import * as styles from "./ChangeRate.css";
+
+interface ChangeRateProps {
+  value: number;
+  typography?: "body2" | "body3" | "body4";
+  className?: string;
+  children?: React.ReactNode;
+}
+
+export default function ChangeRate({
+  value,
+  typography = "body4",
+  className,
+  children,
+}: ChangeRateProps) {
+  const direction = value > 0 ? "positive" : value < 0 ? "negative" : "neutral";
+
+  return (
+    <span
+      className={[
+        styles.directionStyle[direction],
+        styles.typographyStyle[typography],
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      {children ?? `${value >= 0 ? "+" : ""}${value}%`}
+    </span>
+  );
+}

--- a/src/shared/components/ChangeRate/ChangeRate.tsx
+++ b/src/shared/components/ChangeRate/ChangeRate.tsx
@@ -7,7 +7,7 @@ interface ChangeRateProps {
   children?: React.ReactNode;
 }
 
-export default function ChangeRate({
+export function ChangeRate({
   value,
   typography = "body4",
   className,

--- a/src/shared/components/ChangeRate/index.ts
+++ b/src/shared/components/ChangeRate/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ChangeRate";

--- a/src/shared/components/ChangeRate/index.ts
+++ b/src/shared/components/ChangeRate/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./ChangeRate";

--- a/src/shared/components/Logo/Logo.css.ts
+++ b/src/shared/components/Logo/Logo.css.ts
@@ -1,0 +1,14 @@
+import { style } from "@vanilla-extract/css";
+
+export const base = style({
+  borderRadius: "50%",
+  flexShrink: 0,
+  objectFit: "cover",
+});
+
+export const fallback = style([
+  base,
+  {
+    backgroundColor: "#FEF2F2",
+  },
+]);

--- a/src/shared/components/Logo/Logo.tsx
+++ b/src/shared/components/Logo/Logo.tsx
@@ -1,0 +1,35 @@
+import { useState } from "react";
+import * as styles from "./Logo.css";
+
+interface LogoProps {
+  src?: string | null;
+  alt: string;
+  size?: number;
+  className?: string;
+}
+
+export function Logo({ src, alt, size = 40, className }: LogoProps) {
+  const [hasError, setHasError] = useState(false);
+
+  const sizeStyle = { width: size, height: size };
+
+  if (!src || hasError) {
+    return (
+      <div
+        className={[styles.fallback, className].filter(Boolean).join(" ")}
+        style={sizeStyle}
+        aria-label={alt}
+      />
+    );
+  }
+
+  return (
+    <img
+      className={[styles.base, className].filter(Boolean).join(" ")}
+      style={sizeStyle}
+      src={src}
+      alt={alt}
+      onError={() => setHasError(true)}
+    />
+  );
+}

--- a/src/shared/components/index.ts
+++ b/src/shared/components/index.ts
@@ -1,0 +1,2 @@
+export { ChangeRate } from "./ChangeRate/ChangeRate";
+export { Badge } from "./Badge/Badge";

--- a/src/shared/components/index.ts
+++ b/src/shared/components/index.ts
@@ -1,2 +1,3 @@
 export { ChangeRate } from "./ChangeRate/ChangeRate";
 export { Badge } from "./Badge/Badge";
+export { Logo } from "./Logo/Logo";

--- a/src/shared/styles/color.role.css.ts
+++ b/src/shared/styles/color.role.css.ts
@@ -1,3 +1,8 @@
+export const accentColor = {
+  red: "#FF383C",
+  blue: "#0088FF",
+} as const;
+
 export const roleColor = {
   primary: "#00BECC",
   secondary: "#008F99",

--- a/src/shared/styles/color.semantic.css.ts
+++ b/src/shared/styles/color.semantic.css.ts
@@ -1,8 +1,9 @@
 import { green, blue, grey, blueGreen } from "./color.scale.css";
-import { roleColor } from "./color.role.css";
+import { roleColor, accentColor } from "./color.role.css";
 
 export const color = {
   role: roleColor,
+  accent: accentColor,
   green: {
     light: green[50],
     lightHover: green[100],

--- a/src/shared/styles/vars.css.ts
+++ b/src/shared/styles/vars.css.ts
@@ -4,6 +4,7 @@ import { typography } from "./typography.css";
 
 export const [themeClass, vars] = createTheme({
   color: {
+    accent: color.accent,
     green: color.green,
     blue: color.blue,
     blueGreen: color.blueGreen,


### PR DESCRIPTION
## PR 설명

Home 페이지에 분산되어 있던 UI 로직을 공용 컴포넌트로 추출하고 `shared/components` 배럴 export를 도입했습니다.

- [x] `ChangeRate` — 변동률 표시, 색상/부호 로직 통합
- [x] `Badge` — 섹터 태그 표시
- [x] `Logo` — 이미지 로드 실패 시 fallback div 자동 전환

<br>

## 스크린샷
<img width="600" height="742" alt="screenshot-home" src="https://github.com/user-attachments/assets/3fe704bf-c5ce-477d-af81-d4dc6d7c6365" />
<img width="600" height="742" alt="screenshot-home-scrolled" src="https://github.com/user-attachments/assets/dfe1d3c5-11db-4348-851c-5aac1f2aad2c" />



<br>

## 추가 설명

- `Logo`는 `src`가 없거나 로드 실패 시 fallback으로 자동 전환됩니다. 추후 실제 `logoUrl` 연결 시 별도 수정 없이 이미지가 표시됩니다.
- 공용 컴포넌트 적용 후 각 컴포넌트의 로컬 스타일을 제거하여 중복을 해소했습니다.